### PR TITLE
Move to Reflection Type API

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -4,7 +4,6 @@ namespace Phprest;
 
 use InvalidArgumentException;
 use League\BooBoo\BooBoo;
-use League\Container\Container;
 use League\Container\ContainerInterface;
 use League\Event\Emitter as EventEmitter;
 use League\Event\EmitterInterface as EventEmitterInterface;

--- a/src/Container.php
+++ b/src/Container.php
@@ -40,21 +40,22 @@ class Container extends \League\Container\Container
         foreach ($constructor->getParameters() as $param) {
             $dependency = $param->getType();
 
-            // if the dependency is not a class we attempt to get a default value
-            if (is_null($dependency) || !class_exists($dependency->getName())) {
-                if ($param->isDefaultValueAvailable()) {
-                    $definition->withArgument($param->getDefaultValue());
-                    continue;
-                }
-
-                throw new \League\Container\Exception\UnresolvableDependencyException(
-                    sprintf('Unable to resolve a non-class dependency of [%s] for [%s]', $param, $class)
-                );
+            if ($dependency instanceof ReflectionNamedType && class_exists($dependency->getName())) {
+                // if the dependency is a class, just register its name as an
+                // argument with the definition
+                $definition->withArgument($dependency->getName());
+                continue;
             }
 
-            // if the dependency is a class, just register its name as an
-            // argument with the definition
-            $definition->withArgument($dependency->getName());
+            // if the dependency is not a class we attempt to get a default value
+            if ($param->isDefaultValueAvailable()) {
+                $definition->withArgument($param->getDefaultValue());
+                continue;
+            }
+
+            throw new \League\Container\Exception\UnresolvableDependencyException(
+                sprintf('Unable to resolve a non-class dependency of [%s] for [%s]', $param, $class)
+            );
         }
 
         return $definition;

--- a/src/Container.php
+++ b/src/Container.php
@@ -23,9 +23,10 @@ class Container extends \League\Container\Container
             $reflection  = new \ReflectionClass($class);
             $constructor = $reflection->getConstructor();
         } catch (\ReflectionException $e) {
-            throw new \League\Container\Exception\ReflectionException(
-                sprintf('Unable to reflect on the class [%s], does the class exist and is it properly autoloaded?', $class)
-            );
+            throw new \League\Container\Exception\ReflectionException(sprintf(
+                'Unable to reflect on the class [%s], does the class exist and is it properly autoloaded?',
+                $class
+            ));
         }
 
         $factory = $this->getDefinitionFactory();

--- a/src/Container.php
+++ b/src/Container.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phprest;
+
+use ReflectionNamedType;
+use ReflectionType;
+
+use function class_exists;
+use function is_null;
+use function sprintf;
+
+class Container extends \League\Container\Container
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function reflect($class)
+    {
+        // try to reflect on the class so we can build a definition
+        try {
+            $reflection  = new \ReflectionClass($class);
+            $constructor = $reflection->getConstructor();
+        } catch (\ReflectionException $e) {
+            throw new \League\Container\Exception\ReflectionException(
+                sprintf('Unable to reflect on the class [%s], does the class exist and is it properly autoloaded?', $class)
+            );
+        }
+
+        $factory = $this->getDefinitionFactory();
+        $definition = $factory($class, $class, $this);
+
+        if (is_null($constructor)) {
+            return $definition;
+        }
+
+        // loop through dependencies and get aliases/values
+        foreach ($constructor->getParameters() as $param) {
+            $dependency = $param->getType();
+
+            // if the dependency is not a class we attempt to get a default value
+            if (is_null($dependency) || !class_exists($dependency->getName())) {
+                if ($param->isDefaultValueAvailable()) {
+                    $definition->withArgument($param->getDefaultValue());
+                    continue;
+                }
+
+                throw new \League\Container\Exception\UnresolvableDependencyException(
+                    sprintf('Unable to resolve a non-class dependency of [%s] for [%s]', $param, $class)
+                );
+            }
+
+            // if the dependency is a class, just register its name as an
+            // argument with the definition
+            $definition->withArgument($dependency->getName());
+        }
+
+        return $definition;
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -8,7 +8,7 @@ use Phprest\Config;
 use Phprest\Service\Logger\Config as LoggerConfig;
 use Phprest\Service\Logger\Service as LoggerService;
 use Phprest\Service\Hateoas;
-use League\Container\Container;
+use Phprest\Container;
 use League\Route\RouteCollection;
 use League\Event\Emitter;
 use Phprest\ErrorHandler\Handler\Log;

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phprest\Test;
+
+use League\Container\Exception\UnresolvableDependencyException;
+use Phprest\Container;
+use PHPUnit\Framework\TestCase;
+
+class ContainerTest extends TestCase
+{
+    public function testGettingReflectClass()
+    {
+        $obj = new Container();
+        $obj->add(RegisteredInterface::class, new RegisteredClass());
+        $obj->add(RegisteredClass::class, new RegisteredClass());
+
+        $result = $obj->get(TestCaseClass1::class);
+        $this->assertInstanceOf(TestCaseClass1::class, $result);
+        $this->assertInstanceOf(RegisteredInterface::class, $result->registeredInterface);
+        $this->assertInstanceOf(RegisteredClass::class, $result->registeredClass);
+        $this->assertInstanceOf(UnregisteredClass::class, $result->unregisteredClass);
+        $this->assertInstanceOf(EasyToResolveClass::class, $result->easyToResolveClass);
+        $this->assertInstanceOf(HardToResolveClass::class, $result->hardToResolveClass);
+        $this->assertNull($result->unregisteredInterfaceWithDefault);
+        $this->assertInstanceOf(UnregisteredClass::class, $result->unregisteredClassWithDefault);
+        $this->assertTrue($result->bool);
+        $this->assertEquals(1, $result->int);
+        $this->assertEquals(1.1, $result->float);
+        $this->assertEquals('string', $result->string);
+        $this->assertEquals([], $result->array);
+        $this->assertNull($result->object);
+        $this->assertNull($result->callable);
+        $this->assertNull($result->iterable);
+        $this->assertNull($result->resource);
+        $this->assertNull($result->null);
+    }
+
+    public function testGettingReflectedClassThatCantBeResolved()
+    {
+        $obj = new Container();
+
+        $this->expectException(UnresolvableDependencyException::class);
+        $obj->get(TestCaseClass2::class);
+    }
+}
+
+interface RegisteredInterface {}
+interface UnregisteredInterface {}
+class RegisteredClass implements RegisteredInterface {}
+class UnregisteredClass implements UnregisteredInterface {}
+class EasyToResolveClass {}
+class HardToResolveClass
+{
+    public RegisteredInterface $test;
+
+    public function __construct(RegisteredInterface $test)
+    {
+        $this->test = $test;
+    }
+}
+class UnresolvableClass
+{
+    public UnregisteredInterface $test;
+
+    public function __construct(UnregisteredInterface $test)
+    {
+        $this->test = $test;
+    }
+}
+
+class TestCaseClass1
+{
+    public RegisteredInterface $registeredInterface;
+    public RegisteredClass $registeredClass;
+    public UnregisteredClass $unregisteredClass;
+    public EasyToResolveClass $easyToResolveClass;
+    public HardToResolveClass $hardToResolveClass;
+    public ?UnregisteredInterface $unregisteredInterfaceWithDefault;
+    public ?UnregisteredClass $unregisteredClassWithDefault;
+    public bool $bool;
+    public int $int;
+    public float $float;
+    public string $string;
+    public array $array;
+    public ?object $object;
+    /**
+     * @var callable|null
+     */
+    public $callable;
+    public ?iterable $iterable;
+    /**
+     * @var null
+     */
+    public $resource;
+    /**
+     * @var null
+     */
+    public $null;
+
+    public function __construct(
+        RegisteredInterface $registeredInterface,
+        RegisteredClass $registeredClass,
+        UnregisteredClass $unregisteredClass,
+        EasyToResolveClass $easyToResolveClass,
+        HardToResolveClass $hardToResolveClass,
+        UnregisteredInterface $unregisteredInterfaceWithDefault = null,
+        UnregisteredClass $unregisteredClassWithDefault = null,
+        bool $bool = true,
+        int $int = 1,
+        float $float = 1.1,
+        string $string = 'string',
+        array $array = [],
+        object $object = null,
+        callable $callable = null,
+        iterable $iterable = null,
+        $resource = null,
+        $null = null
+    ) {
+        $this->registeredInterface = $registeredInterface;
+        $this->registeredClass = $registeredClass;
+        $this->unregisteredClass = $unregisteredClass;
+        $this->easyToResolveClass = $easyToResolveClass;
+        $this->hardToResolveClass = $hardToResolveClass;
+        $this->unregisteredInterfaceWithDefault = $unregisteredInterfaceWithDefault;
+        $this->unregisteredClassWithDefault = $unregisteredClassWithDefault;
+        $this->bool = $bool;
+        $this->int = $int;
+        $this->float = $float;
+        $this->string = $string;
+        $this->array = $array;
+        $this->object = $object;
+        $this->callable = $callable;
+        $this->iterable = $iterable;
+        $this->resource = $resource;
+        $this->null = $null;
+    }
+}
+
+class TestCaseClass2
+{
+    public UnresolvableClass $unresolvableClass;
+
+    public function __construct(UnresolvableClass $unresolvableClass)
+    {
+        $this->unresolvableClass = $unresolvableClass;
+    }
+}

--- a/tests/Router/StrategyTest.php
+++ b/tests/Router/StrategyTest.php
@@ -5,7 +5,7 @@ namespace Phprest\Test\Router;
 use Phprest\Application;
 use Phprest\Router\Strategy;
 use Phprest\Service;
-use League\Container\Container;
+use Phprest\Container;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Phprest\HttpFoundation\Response;

--- a/tests/Service/Hateoas/HateoasTest.php
+++ b/tests/Service/Hateoas/HateoasTest.php
@@ -7,7 +7,7 @@ use Phprest\Service\Hateoas\Config;
 use Phprest\Service\Hateoas\Getter;
 use Phprest\Service\Hateoas\Service;
 use Phprest\Stub\Service\SampleConfig;
-use League\Container\Container;
+use Phprest\Container;
 use Hateoas\Hateoas;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Service/Hateoas/UtilTest.php
+++ b/tests/Service/Hateoas/UtilTest.php
@@ -3,7 +3,7 @@
 namespace Phprest\Test\Service\Hateoas;
 
 use Phprest\Application;
-use League\Container\Container;
+use Phprest\Container;
 use Phprest\Exception\NotAcceptable;
 use Phprest\Exception\UnsupportedMediaType;
 use Phprest\Service\Hateoas\Config;

--- a/tests/Service/Logger/LoggerTest.php
+++ b/tests/Service/Logger/LoggerTest.php
@@ -3,7 +3,7 @@
 namespace Phprest\Test\Service\Logger;
 
 use InvalidArgumentException;
-use League\Container\Container;
+use Phprest\Container;
 use Phprest\Service\Logger\Config;
 use Phprest\Service\Logger\Getter;
 use Phprest\Service\Logger\Service;

--- a/tests/Util/ControllerTest.php
+++ b/tests/Util/ControllerTest.php
@@ -6,7 +6,7 @@ use Phprest\Application;
 use Phprest\HttpFoundation\Response;
 use Phprest\Stub\Controller\Routed as RoutedController;
 use Phprest\Router\RouteCollection;
-use League\Container\Container;
+use Phprest\Container;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Util/MimeTest.php
+++ b/tests/Util/MimeTest.php
@@ -3,7 +3,7 @@
 namespace Phprest\Test\Util;
 
 use Phprest\Application;
-use League\Container\Container;
+use Phprest\Container;
 use Phprest\Util\DataStructure\MimeProcessResult;
 use Phprest\Util\Mime;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Adding back support for Reflection Type API. This time if the reflection type does return NULL, or scalar type,  special type, or compound types that are not class objects then we try to simply get the default value or throw an exception, otherwise try to create the dependency.