### PR TITLE
Hotfix/singleton check

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -6,6 +6,7 @@ namespace Phprest;
 
 use ReflectionNamedType;
 
+use function array_key_exists;
 use function class_exists;
 use function in_array;
 use function is_null;
@@ -25,6 +26,21 @@ class Container extends \League\Container\Container
         'iterable',
         'resource',
     ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSingleton($alias)
+    {
+        return (
+            array_key_exists($alias, $this->singletons)
+            || (
+                array_key_exists($alias, $this->items)
+                && isset($this->items[$alias]['singleton'])
+                && $this->items[$alias]['singleton'] === true
+            )
+        );
+    }
 
     /**
      * {@inheritDoc}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -44,6 +44,14 @@ class ContainerTest extends TestCase
         $this->expectException(UnresolvableDependencyException::class);
         $obj->get(TestCaseClass2::class);
     }
+
+    public function testResolvingDynamiclyDefinedDependenciesOfClasses()
+    {
+        $obj = new Container();
+
+        $this->assertInstanceOf(TestCaseClass3::class, $obj->get(TestCaseClass3::class));
+        $this->assertInstanceOf(TestCaseClass31::class, $obj->get(TestCaseClass31::class));
+    }
 }
 
 interface RegisteredInterface {}
@@ -146,4 +154,11 @@ class TestCaseClass2
     {
         $this->unresolvableClass = $unresolvableClass;
     }
+}
+
+class TestCaseClass3 {}
+
+class TestCaseClass31
+{
+    public function __construct(TestCaseClass3 $testCase3) {}
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -160,5 +160,10 @@ class TestCaseClass3 {}
 
 class TestCaseClass31
 {
-    public function __construct(TestCaseClass3 $testCase3) {}
+    public TestCaseClass3 $testCase3;
+
+    public function __construct(TestCaseClass3 $testCase3)
+    {
+        $this->testCase3 = $testCase3;
+    }
 }


### PR DESCRIPTION
If you resolve a dependency automatically which then needs a dependency that is also resolved automatically we need to check if it is registered or is a singleton instance or is a class that exists, if one of those 3 is true we then add it to the definition to create the instance. There is a bug in the method for checking if the alias is a singleton, it does not make sure the singleton key exists in the items array and results in `Undefined array key "singleton"`. I managed to reproduce and fix the issue and added unit test for it.