### PR TITLE
Monolog upgrade to v2

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -3,29 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  test-php74:
-
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - uses: shivammathur/setup-php@v2
-      with:
-        php-version: '7.4'
-        tools: composer, phpunit
-      env:
-        COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install dependencies
-      run: composer install
-    - name: Run unit tests
-      run: vendor/bin/phpunit
-    - name: Run PHPCS check
-      run: vendor/bin/phpcs --report-full --standard=PSR12 src
-    - name: Run phpstan check
-      run: vendor/bin/phpstan analyse
-
-  test-php80:
+  test-php81:
     runs-on: ubuntu-latest
 
     steps:
@@ -33,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           tools: composer, phpunit
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,7 +24,7 @@ jobs:
       - name: Run phpstan check
         run: vendor/bin/phpstan analyse
 
-  test-php81:
+  test-php82:
     runs-on: ubuntu-latest
 
     steps:
@@ -54,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           tools: composer, phpunit
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "league/booboo": "^1.1",
         "league/container": "^1.3",
         "league/event": "^2.2",
         "league/route": "^1.2.5",
-        "monolog/monolog": "^1.12",
+        "monolog/monolog": "^2.0",
         "stack/builder": "^1.0",
-        "symfony/console": "^3.4 || ^4.4",
+        "symfony/console": "^4.4",
         "symfony/http-kernel": "^4.4",
         "willdurand/hateoas": "^3.8",
         "willdurand/negotiation": "^1.5"

--- a/src/Application.php
+++ b/src/Application.php
@@ -52,8 +52,6 @@ class Application implements
         $this->router = $configuration->getRouter();
         $this->emitter = $configuration->getEventEmitter();
 
-        AnnotationRegistry::registerLoader('class_exists');
-
         $this->registerService($configuration->getHateoasService(), $configuration->getHateoasConfig());
         $this->registerService($configuration->getLoggerService(), $configuration->getLoggerConfig());
 

--- a/tests/ErrorHandler/Formatter/JsonXmlTest.php
+++ b/tests/ErrorHandler/Formatter/JsonXmlTest.php
@@ -60,8 +60,6 @@ class JsonXmlTest extends TestCase
      */
     protected function setContainerElements(Config $config): void
     {
-        AnnotationRegistry::registerLoader('class_exists');
-
         $config->getHateoasService()->register(
             $config->getContainer(),
             $config->getHateoasConfig()

--- a/tests/Service/Hateoas/UtilTest.php
+++ b/tests/Service/Hateoas/UtilTest.php
@@ -23,11 +23,6 @@ class UtilTest extends TestCase
 
     private Container $container;
 
-    public static function setUpBeforeClass(): void
-    {
-        AnnotationRegistry::registerLoader('class_exists');
-    }
-
     public function setUp(): void
     {
         $this->container = new Container();

--- a/tests/Util/ControllerTest.php
+++ b/tests/Util/ControllerTest.php
@@ -15,11 +15,6 @@ class ControllerTest extends TestCase
     private RoutedController $controller;
     private RouteCollection $router;
 
-    public static function setUpBeforeClass(): void
-    {
-        AnnotationRegistry::registerLoader('class_exists');
-    }
-
     public function setUp(): void
     {
         $this->router = new RouteCollection();


### PR DESCRIPTION
- Drop support for old PHP versions. Minimum supported version is now 8.1
- Upgrade monolog dependency to v2